### PR TITLE
fix(Issue #41 and #43): Furnace GUI and Lumberjack Crash Fix

### DIFF
--- a/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockData.java
+++ b/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockData.java
@@ -52,6 +52,10 @@ class FortressBuildingBlockData {
         }
     }
 
+    public List<PositionedState> getReferenceState() {
+        return referenceState;
+    }
+
     private FortressBuildingBlockData(NbtCompound tag) {
         if (tag.contains("pointer", NbtType.NUMBER))
             blockPointer = tag.getInt("pointer");
@@ -287,7 +291,7 @@ class FortressBuildingBlockData {
         PRESERVED,
     }
 
-    private record PositionedState(BlockPos pos, BlockState blockState) {
+    public record PositionedState(BlockPos pos, BlockState blockState) {
     }
 
 }

--- a/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockEntity.kt
+++ b/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockEntity.kt
@@ -129,9 +129,6 @@ class FortressBuildingBlockEntity(pos: BlockPos?, state: BlockState?) :
         this.furnaceBlockPositions = this.blockData?.referenceState
             ?.filter { it.blockState?.isOf(Blocks.FURNACE) == true }
             ?.map { it.pos.toImmutable() }
-            ?.asSequence()
-            ?.take(this.upgrades.size * 2) // +1 building level = +2 furnaces
-            ?.toList()
     }
 
     override fun createMenu(syncId: Int, playerInventory: PlayerInventory?, player: PlayerEntity?): ScreenHandler {

--- a/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockEntity.kt
+++ b/src/building/java/net/remmintan/mods/minefortress/blocks/building/FortressBuildingBlockEntity.kt
@@ -129,6 +129,12 @@ class FortressBuildingBlockEntity(pos: BlockPos?, state: BlockState?) :
     override fun getFurnace(): FurnaceBlockEntity? =
         furnaceBlockPos?.let { this.getWorld()?.let { w -> w.getBlockEntity(it) as? FurnaceBlockEntity } }
 
+    override fun getFurnacePos(): BlockPos? =
+        this.blockData?.referenceState
+            ?.filter { it.blockState.block?.translationKey == "block.minecraft.furnace" }
+            ?.map { it.pos }
+            ?.get(0)
+
     override fun createMenu(syncId: Int, playerInventory: PlayerInventory?, player: PlayerEntity?): ScreenHandler {
         val propertyDelegate = object : PropertyDelegate {
             override fun get(index: Int): Int {

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/buildings/IFortressBuilding.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/buildings/IFortressBuilding.java
@@ -79,5 +79,7 @@ public interface IFortressBuilding {
 
     FurnaceBlockEntity getFurnace();
 
+    BlockPos getFurnacePos();
+
     IBuildingHireHandler getHireHandler();
 }

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/buildings/IFortressBuilding.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/buildings/IFortressBuilding.java
@@ -77,9 +77,9 @@ public interface IFortressBuilding {
 
     Map<BlockPos, BlockState> getBlocksToRepair();
 
-    FurnaceBlockEntity getFurnace();
+    List<BlockPos> getFurnacePos();
 
-    BlockPos getFurnacePos();
+    void findFurnaces();
 
     IBuildingHireHandler getHireHandler();
 }

--- a/src/main/java/org/minefortress/entity/ai/professions/LumberjackDailyTask.java
+++ b/src/main/java/org/minefortress/entity/ai/professions/LumberjackDailyTask.java
@@ -93,7 +93,7 @@ public class LumberjackDailyTask extends AbstractAutomationAreaTask {
             } else {
                 ServerModUtils.getManagersProvider(colonist)
                         .ifPresent(it ->
-                                new TreeRemover((ServerWorld) world, null, colonist).removeTheTree(tree));
+                                new TreeRemover((ServerWorld) world, it.getResourceManager(), colonist).removeTheTree(tree));
 
                 tree = null;
             }

--- a/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
+++ b/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
@@ -37,18 +37,17 @@ public class FurnaceScreenHandlerFactory implements NamedScreenHandlerFactory {
             final var provider = ServerModUtils.getManagersProvider(serverPlayer).orElseThrow();
             final var professionManager = provider.getProfessionsManager();
             final var blacksmithsCount = professionManager.getProfession("blacksmith").getAmount();
-            final var otherFurnaceBlocks = provider
+            final var otherFurnacePositions = provider
                     .getBuildingsManager()
                     .getBuildings(ProfessionType.BLACKSMITH)
                     .stream()
                     .limit(blacksmithsCount)
-                    .map(IFortressBuilding::getFurnace)
+                    .map(IFortressBuilding::getFurnacePos)
                     .filter(Objects::nonNull)
-                    .map(BlockEntity::getPos)
                     .toList();
 
-            final BlockPos selectedFurnacePos = furnacePos == null ? otherFurnaceBlocks.get(0) : furnacePos;
-            final var otherFurnacesDelegates = otherFurnaceBlocks.stream()
+            final BlockPos selectedFurnacePos = furnacePos == null ?  otherFurnacePositions.get(0) : furnacePos;
+            final var otherFurnacesDelegates = otherFurnacePositions.stream()
                     .map(it -> {
                         final var blockEnt = player.getWorld().getBlockEntity(it);
                         if (blockEnt instanceof FurnaceBlockEntity furnaceBlockEntity) {

--- a/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
+++ b/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
@@ -48,7 +48,7 @@ public class FurnaceScreenHandlerFactory implements NamedScreenHandlerFactory {
                     .toList();
 
             final BlockPos selectedFurnacePos = furnacePos == null ?  otherFurnacePositions.get(0).get(0) : furnacePos;
-            final var otherFurnacesDelegates = otherFurnacePositions.stream().flatMap(List::stream)
+            final var otherFurnacesDelegates = otherFurnacePositions.stream().flatMap(List::stream).limit(blacksmithsCount)
                     .map(it -> {
                         final var blockEnt = player.getWorld().getBlockEntity(it);
                         if (blockEnt instanceof FurnaceBlockEntity furnaceBlockEntity) {

--- a/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
+++ b/src/main/java/org/minefortress/fortress/resources/gui/smelt/FurnaceScreenHandlerFactory.java
@@ -15,6 +15,7 @@ import net.remmintan.mods.minefortress.core.interfaces.buildings.IFortressBuildi
 import net.remmintan.mods.minefortress.core.utils.ServerModUtils;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Objects;
 
 public class FurnaceScreenHandlerFactory implements NamedScreenHandlerFactory {
@@ -46,12 +47,12 @@ public class FurnaceScreenHandlerFactory implements NamedScreenHandlerFactory {
                     .filter(Objects::nonNull)
                     .toList();
 
-            final BlockPos selectedFurnacePos = furnacePos == null ?  otherFurnacePositions.get(0) : furnacePos;
-            final var otherFurnacesDelegates = otherFurnacePositions.stream()
+            final BlockPos selectedFurnacePos = furnacePos == null ?  otherFurnacePositions.get(0).get(0) : furnacePos;
+            final var otherFurnacesDelegates = otherFurnacePositions.stream().flatMap(List::stream)
                     .map(it -> {
                         final var blockEnt = player.getWorld().getBlockEntity(it);
                         if (blockEnt instanceof FurnaceBlockEntity furnaceBlockEntity) {
-                            return (PropertyDelegate)new FortressFurnacePropertyDelegateImpl(furnaceBlockEntity, furnaceBlockEntity.getPos().equals(selectedFurnacePos));
+                            return (PropertyDelegate) new FortressFurnacePropertyDelegateImpl(furnaceBlockEntity, furnaceBlockEntity.getPos().equals(selectedFurnacePos));
                         }
                         return null;
                     })


### PR DESCRIPTION
I noticed that the `furnaceBlockPos` was not being saved or loaded correctly, but it also didn't seem implemented right (in my testing). When I had multiple blacksmiths down, I was only able to access a single furnace. 

Using this new system, the furnace blocks within each Blacksmith are scanned, then the position is returned (Only limited to one furnace per blacksmith building since I believe that's how it was originally intended). 

This prevents needing to save the furnace position in the case where it fails. This fix will also make existing broken worlds become functional again.