### PR TITLE
fix(Issue #43): Fixed crash when lumberjacks chop trees.

### DIFF
--- a/src/main/java/org/minefortress/entity/ai/professions/LumberjackDailyTask.java
+++ b/src/main/java/org/minefortress/entity/ai/professions/LumberjackDailyTask.java
@@ -93,7 +93,7 @@ public class LumberjackDailyTask extends AbstractAutomationAreaTask {
             } else {
                 ServerModUtils.getManagersProvider(colonist)
                         .ifPresent(it ->
-                                new TreeRemover((ServerWorld) world, null, colonist).removeTheTree(tree));
+                                new TreeRemover((ServerWorld) world, it.getResourceManager(), colonist).removeTheTree(tree));
 
                 tree = null;
             }


### PR DESCRIPTION
Changed null parameter, which was not accepted, to it.getResourceManager(), which appears to work as intended.

This commit has been moved out of PR #42 as requested. I had accidentally pushed the lumberjack fix to that PR, I probably should have split them originally. 