### PR TITLE
Select pawns for tasks based on their distance to the task

### DIFF
--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
@@ -1,6 +1,7 @@
 package net.remmintan.mods.minefortress.core.interfaces.entities.pawns;
 
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Vec3d;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IAreaBasedTaskControl;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
 
@@ -9,5 +10,5 @@ public interface IWorkerPawn extends IFortressAwareEntity, IProfessional {
     IAreaBasedTaskControl getAreaBasedTaskControl();
     ITaskControl getTaskControl();
     ServerWorld getServerWorld();
-
+    Vec3d getPos();
 }

--- a/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
+++ b/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
@@ -103,16 +103,17 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
     }
 
     private fun setPawnsToTask(task: IBaseTask, workers: List<IWorkerPawn>) {
+        val sortedWorkers = workers.sortedBy { task.pos.getSquaredDistance(it.pos) }
         when (task) {
             is ITask ->
-                for (worker in workers) {
+                for (worker in sortedWorkers) {
                     if (!task.hasAvailableParts() || !task.canTakeMoreWorkers()) break
                     task.addWorker()
                     worker.taskControl.setTask(task)
                 }
 
             is IAreaBasedTask ->
-                for (worker in workers) {
+                for (worker in sortedWorkers) {
                     if (!task.hasMoreBlocks() || !task.canTakeMoreWorkers()) break
                     task.addWorker()
                     worker.areaBasedTaskControl.setTask(task)


### PR DESCRIPTION
Sort the array of pawns based on their distance before starting setting them to the task.
Requires change to the `IWorkerPawn` interface to allow access to position of the pawn.