### PR TITLE
Pawn selection improvement

### DIFF
--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
@@ -4,11 +4,13 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Vec3d;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IAreaBasedTaskControl;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskQueueControl;
 
 public interface IWorkerPawn extends IFortressAwareEntity, IProfessional {
 
     IAreaBasedTaskControl getAreaBasedTaskControl();
     ITaskControl getTaskControl();
+    ITaskQueueControl getTaskQueueControl();
     ServerWorld getServerWorld();
     Vec3d getPos();
 }

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/IWorkerPawn.java
@@ -1,6 +1,7 @@
 package net.remmintan.mods.minefortress.core.interfaces.entities.pawns;
 
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Vec3d;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IAreaBasedTaskControl;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
 
@@ -9,5 +10,5 @@ public interface IWorkerPawn extends IFortressAwareEntity, IProfessional {
     IAreaBasedTaskControl getAreaBasedTaskControl();
     ITaskControl getTaskControl();
     ServerWorld getServerWorld();
-
+    Vec3d getPos();
 }

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/IAreaBasedTaskControl.kt
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/IAreaBasedTaskControl.kt
@@ -15,6 +15,5 @@ interface IAreaBasedTaskControl {
     fun moveToNextBlock(): ITaskBlockInfo?
     fun reset()
     fun tick()
-    fun readyToTakeNewTask(): Boolean
 
 }

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/ITaskControl.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/ITaskControl.java
@@ -18,10 +18,6 @@ public interface ITaskControl {
 
     boolean hasTaskPart();
 
-    void setDoingEverydayTasks(boolean doingEverydayTasks);
-
-    boolean isDoingEverydayTasks();
-
     boolean partHasMoreBlocks();
 
     void findNextPart();
@@ -31,8 +27,6 @@ public interface ITaskControl {
     @Nullable ITaskBlockInfo getNextBlock();
 
     void tick();
-
-    boolean readyToTakeNewTask();
 
     boolean taskIsOfType(Class<? extends IBaseTask> taskClass);
 }

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/ITaskQueueControl.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/entities/pawns/controls/ITaskQueueControl.java
@@ -1,0 +1,21 @@
+package net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls;
+
+import net.minecraft.util.math.BlockPos;
+import net.remmintan.mods.minefortress.core.interfaces.tasks.IBaseTask;
+
+public interface ITaskQueueControl {
+    void addTask(IBaseTask task);
+    boolean hasTasks();
+    boolean isOnTask(IBaseTask task);
+
+    void cancelCurrent();
+    boolean currentTaskIsOfType(Class<? extends IBaseTask> taskClass);
+
+    void setDoingEverydayTasks(boolean doingEverydayTasks);
+    boolean isDoingEverydayTasks();
+
+    double estimateTimeRequired();
+    BlockPos getLastPos();
+
+    void tick();
+}

--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/tasks/IBaseTask.kt
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/tasks/IBaseTask.kt
@@ -23,5 +23,5 @@ interface IBaseTask {
     fun canTakeMoreWorkers(): Boolean
     fun addWorker()
     fun removeWorker()
-
+    fun estimateTimeRequired(): Double
 }

--- a/src/main/java/org/minefortress/MineFortressConstants.java
+++ b/src/main/java/org/minefortress/MineFortressConstants.java
@@ -5,4 +5,7 @@ public class MineFortressConstants {
     public static final double PICK_DISTANCE = 120;
     public static final float PICK_DISTANCE_FLOAT = (float) PICK_DISTANCE;
 
+    public static final double ESTIMATED_BREAKING_TIME = (0.4 * 5.0 + 0.6) / 6.0; // In seconds per block. Calculation: (0.4 (Dirt mining speed) * 5 + 0.6 (Stone mining speed)) / 6
+    public static final double ESTIMATED_PLACING_TIME = 4.0 / 20.0; // In seconds per block. "#rightClickSpeed" taken from baritone, 4 ticks = 0.2.
+    public static final double ESTIMATED_RUNNING_SPEED = 5.612; // In blocks per second.
 }

--- a/src/main/java/org/minefortress/MineFortressConstants.java
+++ b/src/main/java/org/minefortress/MineFortressConstants.java
@@ -8,4 +8,7 @@ public class MineFortressConstants {
     public static final double ESTIMATED_BREAKING_TIME = (0.4 * 5.0 + 0.6) / 6.0; // In seconds per block. Calculation: (0.4 (Dirt mining speed) * 5 + 0.6 (Stone mining speed)) / 6
     public static final double ESTIMATED_PLACING_TIME = 4.0 / 20.0; // In seconds per block. "#rightClickSpeed" taken from baritone, 4 ticks = 0.2.
     public static final double ESTIMATED_RUNNING_SPEED = 5.612; // In blocks per second.
+
+    public static final int TASK_COOLDOWN = 20; // In ticks.
+    public static final double TASK_COOLDOWN_IN_SEC = TASK_COOLDOWN / 20.0; // In seconds.
 }

--- a/src/main/java/org/minefortress/MineFortressConstants.java
+++ b/src/main/java/org/minefortress/MineFortressConstants.java
@@ -1,14 +1,17 @@
 package org.minefortress;
 
+import org.minefortress.entity.Colonist;
+
 public class MineFortressConstants {
 
     public static final double PICK_DISTANCE = 120;
     public static final float PICK_DISTANCE_FLOAT = (float) PICK_DISTANCE;
 
-    public static final double ESTIMATED_BREAKING_TIME = (0.4 * 5.0 + 0.6) / 6.0; // In seconds per block. Calculation: (0.4 (Dirt mining speed) * 5 + 0.6 (Stone mining speed)) / 6
-    public static final double ESTIMATED_PLACING_TIME = 4.0 / 20.0; // In seconds per block. "#rightClickSpeed" taken from baritone, 4 ticks = 0.2.
-    public static final double ESTIMATED_RUNNING_SPEED = 5.612; // In blocks per second.
-
+    public static final float PLACE_COOLDOWN = 6f;
     public static final int TASK_COOLDOWN = 20; // In ticks.
     public static final double TASK_COOLDOWN_IN_SEC = TASK_COOLDOWN / 20.0; // In seconds.
+
+    public static final double ESTIMATED_BREAKING_TIME = (0.4 * 5.0 + 0.6) / 6.0; // In seconds per block. Calculation: (0.4 (Dirt mining speed) * 5 + 0.6 (Stone mining speed)) / 6
+    public static final double ESTIMATED_PLACING_TIME = PLACE_COOLDOWN / 20.0; // In seconds per block. "#rightClickSpeed" taken from baritone, 4 ticks = 0.2.
+    public static final double ESTIMATED_RUNNING_SPEED = Colonist.FAST_MOVEMENT_SPEED * 20.0; // In blocks per second.
 }

--- a/src/main/java/org/minefortress/entity/Colonist.java
+++ b/src/main/java/org/minefortress/entity/Colonist.java
@@ -32,16 +32,14 @@ import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.IWorkerPaw
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IAreaBasedTaskControl;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IEatControl;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskQueueControl;
 import net.remmintan.mods.minefortress.core.interfaces.server.IServerFortressManager;
 import net.remmintan.mods.minefortress.core.interfaces.server.IServerManagersProvider;
 import net.remmintan.mods.minefortress.core.interfaces.tasks.ITaskBlockInfo;
 import net.remmintan.mods.minefortress.core.utils.ServerModUtils;
 import org.jetbrains.annotations.Nullable;
 import org.minefortress.entity.ai.MovementHelper;
-import org.minefortress.entity.ai.controls.AreaBasedTaskControl;
-import org.minefortress.entity.ai.controls.DigControl;
-import org.minefortress.entity.ai.controls.PlaceControl;
-import org.minefortress.entity.ai.controls.TaskControl;
+import org.minefortress.entity.ai.controls.*;
 import org.minefortress.entity.ai.goal.*;
 import org.minefortress.registries.FortressEntities;
 
@@ -65,6 +63,7 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
     private final PlaceControl placeControl;
     private final ITaskControl taskControl;
     private final IAreaBasedTaskControl areaBasedTaskControl;
+    private final ITaskQueueControl taskQueueControl;
     private final MovementHelper movementHelper;
     private final IBaritone baritone;
 
@@ -78,6 +77,7 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
             placeControl = new PlaceControl(this);
             taskControl = new TaskControl(this);
             areaBasedTaskControl = new AreaBasedTaskControl(this);
+            taskQueueControl = new TaskQueueControl(this, taskControl, areaBasedTaskControl);
             baritone = BaritoneAPI.getProvider().getBaritone(this);
             movementHelper = new MovementHelper(this);
         } else {
@@ -85,6 +85,7 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
             placeControl = null;
             taskControl = null;
             areaBasedTaskControl = null;
+            taskQueueControl = null;
             baritone = null;
             movementHelper = null;
         }
@@ -228,10 +229,7 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
     public void tick() {
         super.tick();
 
-        boolean taskControlHasTask = this.taskControl != null && (taskControl.hasTask() || taskControl.isDoingEverydayTasks());
-        boolean areaTaskControlHasTask = this.areaBasedTaskControl != null && areaBasedTaskControl.hasTask();
-        this.setHasTask(taskControlHasTask || areaTaskControlHasTask);
-
+        this.setHasTask(taskQueueControl != null && taskQueueControl.hasTasks());
 
         if((isHalfInWall() || isEyesInTheWall()) && !this.isSleeping())
             this.getJumpControl().setActive();
@@ -246,6 +244,7 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
         if(getMovementHelper() != null) getMovementHelper().tick();
         if (getAreaBasedTaskControl() != null) getAreaBasedTaskControl().tick();
         if (getTaskControl() != null) getTaskControl().tick();
+        if (getTaskQueueControl() != null) getTaskQueueControl().tick();
     }
 
     private boolean isHalfInWall() {
@@ -393,6 +392,11 @@ public class Colonist extends NamedPawnEntity implements IMinefortressEntity, IW
     @Override
     public IAreaBasedTaskControl getAreaBasedTaskControl() {
         return areaBasedTaskControl;
+    }
+
+    @Override
+    public ITaskQueueControl getTaskQueueControl() {
+        return taskQueueControl;
     }
 
     private void setHasTask(boolean hasTask) {

--- a/src/main/java/org/minefortress/entity/ai/controls/AreaBasedTaskControl.kt
+++ b/src/main/java/org/minefortress/entity/ai/controls/AreaBasedTaskControl.kt
@@ -12,8 +12,6 @@ class AreaBasedTaskControl(private val pawn: Colonist) : IAreaBasedTaskControl {
     private var task: IAreaBasedTask? = null
     private var currentBlock: ITaskBlockInfo? = null
 
-    private var cooldown: Int = 0
-
     override fun setTask(task: IAreaBasedTask) {
         this.task = task
     }
@@ -51,14 +49,7 @@ class AreaBasedTaskControl(private val pawn: Colonist) : IAreaBasedTaskControl {
         task?.removeWorker()
         this.task = null
         this.currentBlock = null
-        this.cooldown = 20
     }
 
-    override fun tick() {
-        if (cooldown > 0) cooldown--
-    }
-
-    override fun readyToTakeNewTask(): Boolean {
-        return !this.hasTask() && cooldown <= 0
-    }
+    override fun tick() {}
 }

--- a/src/main/java/org/minefortress/entity/ai/controls/PlaceControl.kt
+++ b/src/main/java/org/minefortress/entity/ai/controls/PlaceControl.kt
@@ -7,6 +7,7 @@ import net.remmintan.mods.minefortress.core.utils.BuildingHelper
 import net.remmintan.mods.minefortress.core.utils.SimilarItemsHelper
 import net.remmintan.mods.minefortress.core.utils.getManagersProvider
 import net.remmintan.mods.minefortress.core.utils.isCreativeFortress
+import org.minefortress.MineFortressConstants
 import org.minefortress.entity.Colonist
 import org.minefortress.entity.colonist.IFortressHungerManager
 import org.minefortress.tasks.block.info.BlockStateTaskBlockInfo
@@ -65,7 +66,7 @@ class PlaceControl(private val colonist: Colonist) : PositionedActionControl() {
         if (interactionResult == ActionResult.CONSUME || failedInteractions > 15) {
             if (interactionResult == ActionResult.CONSUME) decreaseResourcesAndAddSpecialBlocksAmount()
             this.reset()
-            this.placeCooldown = 6f
+            this.placeCooldown = MineFortressConstants.PLACE_COOLDOWN
         } else {
             failedInteractions++
         }
@@ -80,7 +81,7 @@ class PlaceControl(private val colonist: Colonist) : PositionedActionControl() {
         decreaseResourcesAndAddSpecialBlocksAmount()
 
         this.reset()
-        this.placeCooldown = 6f
+        this.placeCooldown = MineFortressConstants.PLACE_COOLDOWN
     }
 
     private fun place(blockInfo: ReplaceTaskBlockInfo) {
@@ -92,7 +93,7 @@ class PlaceControl(private val colonist: Colonist) : PositionedActionControl() {
         decreaseResourcesAndAddSpecialBlocksAmount()
 
         this.reset()
-        this.placeCooldown = 6f
+        this.placeCooldown = MineFortressConstants.PLACE_COOLDOWN
     }
 
     private fun decreaseResourcesAndAddSpecialBlocksAmount() {

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskControl.java
@@ -17,11 +17,8 @@ import org.minefortress.tasks.SimpleSelectionTask;
 public class TaskControl implements ITaskControl {
 
     private final Colonist worker;
-    private boolean doingEverydayTasks = false;
     private ITask task;
     private ITaskPart taskPart;
-
-    private int cooldown = 0;
 
     public TaskControl(Colonist worker) {
         this.worker = worker;
@@ -63,16 +60,6 @@ public class TaskControl implements ITaskControl {
     }
 
     @Override
-    public void setDoingEverydayTasks(boolean doingEverydayTasks) {
-        this.doingEverydayTasks = doingEverydayTasks;
-    }
-
-    @Override
-    public boolean isDoingEverydayTasks() {
-        return doingEverydayTasks;
-    }
-
-    @Override
     public boolean partHasMoreBlocks() {
         return taskPart != null && taskPart.hasNext();
     }
@@ -101,14 +88,7 @@ public class TaskControl implements ITaskControl {
     }
 
     @Override
-    public void tick() {
-        if (cooldown > 0) cooldown--;
-    }
-
-    @Override
-    public boolean readyToTakeNewTask() {
-        return cooldown <= 0 && !hasTask() && !isDoingEverydayTasks();
-    }
+    public void tick() {}
 
     public boolean taskIsOfType(Class<? extends IBaseTask> taskClass) {
         return taskClass.isInstance(task);
@@ -143,7 +123,6 @@ public class TaskControl implements ITaskControl {
             this.task = null;
         }
         this.taskPart = null;
-        cooldown = 20;
     }
 
 }

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
@@ -1,0 +1,144 @@
+package org.minefortress.entity.ai.controls;
+
+import net.minecraft.util.math.BlockPos;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.IAreaBasedTaskControl;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskQueueControl;
+import net.remmintan.mods.minefortress.core.interfaces.tasks.IAreaBasedTask;
+import net.remmintan.mods.minefortress.core.interfaces.tasks.IBaseTask;
+import net.remmintan.mods.minefortress.core.interfaces.tasks.ITask;
+import org.minefortress.MineFortressConstants;
+import org.minefortress.entity.Colonist;
+
+import java.util.*;
+
+public class TaskQueueControl implements ITaskQueueControl {
+    private final Deque<IBaseTask> tasks = new ArrayDeque<>();
+    private final Set<IBaseTask> uniqueTasks = new HashSet<>();
+    private IBaseTask currentTask = null;
+
+    private final ITaskControl taskControl;
+    private final IAreaBasedTaskControl areaBasedTaskControl;
+
+    private final Colonist worker;
+    private double requiredTime = 0;
+
+    private int cooldown = 0;
+    private boolean doingEverydayTasks = false;
+
+    public TaskQueueControl(Colonist worker, ITaskControl boundTaskControl, IAreaBasedTaskControl boundAreaBasedTaskControl) {
+        this.worker = worker;
+        taskControl = boundTaskControl;
+        areaBasedTaskControl = boundAreaBasedTaskControl;
+    }
+
+    @Override
+    public void addTask(IBaseTask task) {
+        if(isOnTask(task)) return;
+        task.addWorker();
+        var fromPos = tasks.isEmpty() ? worker.getPos() : tasks.getLast().getPos().toCenterPos();
+        var distanceTravelled = task.getPos().getSquaredDistance(fromPos);
+        distanceTravelled = Math.sqrt(distanceTravelled);
+        tasks.add(task);
+        uniqueTasks.add(task);
+        requiredTime += distanceTravelled / MineFortressConstants.ESTIMATED_RUNNING_SPEED + MineFortressConstants.TASK_COOLDOWN_IN_SEC;
+    }
+
+    @Override
+    public boolean hasTasks() {
+        return currentTask != null && !tasks.isEmpty() && isDoingEverydayTasks();
+    }
+
+    @Override
+    public boolean isOnTask(IBaseTask task) {
+        return uniqueTasks.contains(task);
+    }
+
+    @Override
+    public void cancelCurrent() {
+        if(currentTask != null) {
+            if (currentTask instanceof ITask) {
+                taskControl.fail();
+            } else if (currentTask instanceof IAreaBasedTask) {
+                areaBasedTaskControl.reset();
+            } else {
+                throw new IllegalStateException("Wrong task class");
+            }
+            currentTask = null;
+        }
+    }
+    private boolean isCurrentTaskFinalized() {
+        return currentTask != null && (currentTask.isComplete() || !currentTask.notCancelled());
+    }
+    @Override
+    public void tick() {
+        if (cooldown > 0) cooldown--;
+        if(requiredTime != 0) {
+            requiredTime -= 0.05;
+            if(requiredTime < 0) {
+                requiredTime = 0;
+            }
+        }
+
+        if(isCurrentTaskFinalized()) {
+            uniqueTasks.remove(currentTask);
+            currentTask = null;
+            cooldown = MineFortressConstants.TASK_COOLDOWN;
+            if(tasks.isEmpty())
+                requiredTime = 0;
+        }
+
+        if(currentTask == null && cooldown == 0) {
+            this.currentTask = tasks.poll();
+            if(currentTask == null) {
+                return;
+            }
+            if (currentTask instanceof ITask ct) {
+                if (ct.hasAvailableParts())
+                    taskControl.setTask(ct);
+                else
+                    currentTask = null;
+            } else if (currentTask instanceof IAreaBasedTask abt) {
+                if (abt.hasMoreBlocks())
+                    areaBasedTaskControl.setTask(abt);
+                else
+                    currentTask = null;
+            } else {
+                throw new IllegalStateException("Wrong task class");
+            }
+        }
+    }
+
+    @Override
+    public boolean currentTaskIsOfType(Class<? extends IBaseTask> taskClass) { return taskClass.isInstance(currentTask); }
+
+    @Override
+    public void setDoingEverydayTasks(boolean doingEverydayTasks) {
+        this.doingEverydayTasks = doingEverydayTasks;
+    }
+
+    @Override
+    public boolean isDoingEverydayTasks() {
+        return doingEverydayTasks;
+    }
+
+    @Override
+    public double estimateTimeRequired() {
+        // It would be much more accurate to recompute that each time
+        // since a lot of things can change: workers die, distance travelled faster.
+        // However, doing so will likely incur high compute costs.
+        // Maybe do that as a separate method used only for display purposes?
+        return requiredTime;
+    }
+
+    @Override
+    public BlockPos getLastPos() {
+        if(!tasks.isEmpty()) {
+            return tasks.getLast().getPos();
+        } else if(currentTask != null) {
+            return currentTask.getPos();
+        } else {
+            return worker.getBlockPos();
+        }
+    }
+}

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
@@ -70,22 +70,38 @@ public class TaskQueueControl implements ITaskQueueControl {
     private boolean isCurrentTaskFinalized() {
         return currentTask != null && !taskControl.hasTask() && !areaBasedTaskControl.hasTask();
     }
+    private void removeCurrentTask() {
+        uniqueTasks.remove(currentTask);
+        currentTask = null;
+        cooldown = MineFortressConstants.TASK_COOLDOWN;
+        if(tasks.isEmpty())
+            requiredTime = 0;
+    }
     @Override
     public void tick() {
         if (cooldown > 0) cooldown--;
-        if(requiredTime != 0) {
-            requiredTime -= 0.05;
-            if(requiredTime < 0) {
-                requiredTime = 0;
-            }
-        }
+        if(requiredTime != 0)
+            requiredTime = Math.max(0, requiredTime - 0.05);
 
         if(isCurrentTaskFinalized()) {
-            uniqueTasks.remove(currentTask);
-            currentTask = null;
-            cooldown = MineFortressConstants.TASK_COOLDOWN;
-            if(tasks.isEmpty())
-                requiredTime = 0;
+            // Due to the way tasks choose amount of workers, even if this pawn finished
+            // there still may be place for another pawn. So before finishing task
+            // we check if there still actually no work to do.
+            if (currentTask instanceof ITask ct) {
+                if (ct.hasAvailableParts()) {
+                    ct.addWorker();
+                    taskControl.setTask(ct);
+                }
+                else removeCurrentTask();
+            } else if (currentTask instanceof IAreaBasedTask abt) {
+                if (abt.hasMoreBlocks()) {
+                    abt.addWorker();
+                    areaBasedTaskControl.setTask(abt);
+                }
+                else removeCurrentTask();
+            } else {
+                throw new IllegalStateException("Wrong task class");
+            }
         }
 
         if(currentTask == null && cooldown == 0) {

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
@@ -88,13 +88,13 @@ public class TaskQueueControl implements ITaskQueueControl {
             // there still may be place for another pawn. So before finishing task
             // we check if there still actually no work to do.
             if (currentTask instanceof ITask ct) {
-                if (ct.hasAvailableParts()) {
+                if (ct.canTakeMoreWorkers() && ct.hasAvailableParts()) {
                     ct.addWorker();
                     taskControl.setTask(ct);
                 }
                 else removeCurrentTask();
             } else if (currentTask instanceof IAreaBasedTask abt) {
-                if (abt.hasMoreBlocks()) {
+                if (abt.canTakeMoreWorkers() && abt.hasMoreBlocks()) {
                     abt.addWorker();
                     areaBasedTaskControl.setTask(abt);
                 }

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
@@ -68,7 +68,7 @@ public class TaskQueueControl implements ITaskQueueControl {
         }
     }
     private boolean isCurrentTaskFinalized() {
-        return currentTask != null && (currentTask.isComplete() || !currentTask.notCancelled());
+        return currentTask != null && !taskControl.hasTask() && !areaBasedTaskControl.hasTask();
     }
     @Override
     public void tick() {

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskQueueControl.java
@@ -46,7 +46,7 @@ public class TaskQueueControl implements ITaskQueueControl {
 
     @Override
     public boolean hasTasks() {
-        return currentTask != null && !tasks.isEmpty() && isDoingEverydayTasks();
+        return currentTask != null || !tasks.isEmpty() || isDoingEverydayTasks();
     }
 
     @Override

--- a/src/main/java/org/minefortress/entity/ai/goal/DailyProfessionTasksGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/DailyProfessionTasksGoal.java
@@ -1,6 +1,6 @@
 package org.minefortress.entity.ai.goal;
 
-import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskControl;
+import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.controls.ITaskQueueControl;
 import org.minefortress.entity.Colonist;
 import org.minefortress.entity.ai.professions.*;
 
@@ -29,8 +29,8 @@ public class DailyProfessionTasksGoal extends AbstractFortressGoal {
     @Override
     public boolean canStart() {
         if (this.wantAndCanEatSomeFood()) return false;
-        final ITaskControl taskControl = getTaskControl();
-        if(taskControl.hasTask()) return false;
+        final ITaskQueueControl taskQueueControl = getTaskQueueControl();
+        if(taskQueueControl.hasTasks()) return false;
         final String professionId = colonist.getProfessionId();
 
         for(String professionIdPart : dailyTasks.keySet()) {
@@ -49,7 +49,7 @@ public class DailyProfessionTasksGoal extends AbstractFortressGoal {
 
     @Override
     public void start() {
-        colonist.getTaskControl().setDoingEverydayTasks(true);
+        getTaskQueueControl().setDoingEverydayTasks(true);
         this.currentTask.start(colonist);
     }
 
@@ -63,13 +63,13 @@ public class DailyProfessionTasksGoal extends AbstractFortressGoal {
         return !wantAndCanEatSomeFood()
                 && this.currentTask != null
                 && this.currentTask.shouldContinue(colonist)
-                && !getTaskControl().hasTask();
+                && !getTaskQueueControl().hasTasks();
     }
 
     @Override
     public void stop() {
         this.currentTask.stop(colonist);
-        colonist.getTaskControl().setDoingEverydayTasks(false);
+        getTaskQueueControl().setDoingEverydayTasks(false);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class DailyProfessionTasksGoal extends AbstractFortressGoal {
         return this.wantAndCanEatSomeFood();
     }
 
-    private ITaskControl getTaskControl() {
-        return colonist.getTaskControl();
+    private ITaskQueueControl getTaskQueueControl() {
+        return colonist.getTaskQueueControl();
     }
 }

--- a/src/main/java/org/minefortress/entity/ai/goal/ReturnToFireGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/ReturnToFireGoal.java
@@ -21,7 +21,7 @@ public class ReturnToFireGoal extends AbstractFortressGoal {
     public boolean canStart() {
         if (colonist.getWorld().isDay()) return false;
         if(colonist.getTarget() != null && colonist.getTarget().isAlive()) return false;
-        if(colonist.getTaskControl().hasTask()) return false;
+        if(colonist.getTaskQueueControl().hasTasks()) return false;
         if(!isFarFromCenter()) return false;
 
         ServerModUtils.getFortressManager(colonist)
@@ -41,7 +41,7 @@ public class ReturnToFireGoal extends AbstractFortressGoal {
     @Override
     public boolean shouldContinue() {
         return colonist.getWorld().isNight() &&
-                !colonist.getTaskControl().hasTask() &&
+                !colonist.getTaskQueueControl().hasTasks() &&
                 !colonist.getMovementHelper().isStuck() &&
                 (isFarFromCenter() || colonist.getMovementHelper().stillTryingToReachGoal());
     }

--- a/src/main/java/org/minefortress/entity/ai/goal/SleepOnTheBedGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/SleepOnTheBedGoal.java
@@ -22,7 +22,7 @@ public class SleepOnTheBedGoal extends AbstractFortressGoal {
 
     @Override
     public boolean canStart() {
-        if(!isNight() || colonist.getTaskControl().hasTask()) return false;
+        if(!isNight() || colonist.getTaskQueueControl().hasTasks()) return false;
         final var target = colonist.getTarget();
         if(target != null && target.isAlive()) return false;
         getFreeBed().ifPresent(it -> bedPos = it);
@@ -62,7 +62,7 @@ public class SleepOnTheBedGoal extends AbstractFortressGoal {
 
     @Override
     public boolean shouldContinue() {
-        return isNight() && bedStillValid() && !colonist.getTaskControl().hasTask();
+        return isNight() && bedStillValid() && !colonist.getTaskQueueControl().hasTasks();
     }
 
     @Override

--- a/src/main/java/org/minefortress/entity/ai/goal/WanderAroundTheFortressGoal.kt
+++ b/src/main/java/org/minefortress/entity/ai/goal/WanderAroundTheFortressGoal.kt
@@ -14,7 +14,7 @@ class WanderAroundTheFortressGoal(colonist: Colonist) : AbstractFortressGoal(col
 
     override fun canStart(): Boolean {
         if (colonist.eatControl.map { it.isEating }.orElse(false)) return false
-        if (!isDay || colonist.taskControl.hasTask()) return false
+        if (!isDay || colonist.taskQueueControl.hasTasks()) return false
         val durationSinceStop = Duration.between(stopTime, LocalDateTime.now()).toMillis()
         if (durationSinceStop < delay) return false
 
@@ -44,7 +44,7 @@ class WanderAroundTheFortressGoal(colonist: Colonist) : AbstractFortressGoal(col
     }
 
     override fun shouldContinue(): Boolean {
-        return isDay && !colonist.taskControl.hasTask() && colonist.movementHelper.stillTryingToReachGoal()
+        return isDay && !colonist.taskQueueControl.hasTasks() && colonist.movementHelper.stillTryingToReachGoal()
     }
 
     override fun stop() {

--- a/src/main/java/org/minefortress/fortress/ServerFortressManager.java
+++ b/src/main/java/org/minefortress/fortress/ServerFortressManager.java
@@ -466,7 +466,7 @@ public final class ServerFortressManager implements IServerFortressManager {
     public List<IWorkerPawn> getReadyWorkers() {
         return getWorkersStream()
                 .filter(it -> Colonist.DEFAULT_PROFESSION_ID.equals(it.getProfessionId()))
-                .filter(it -> it.getTaskControl().readyToTakeNewTask() && it.getAreaBasedTaskControl().readyToTakeNewTask())
+                .filter(it -> !it.getTaskQueueControl().isDoingEverydayTasks())
                 .toList();
     }
 

--- a/src/main/java/org/minefortress/tasks/AbstractTask.kt
+++ b/src/main/java/org/minefortress/tasks/AbstractTask.kt
@@ -15,6 +15,7 @@ import net.remmintan.mods.minefortress.core.utils.getFortressOwner
 import net.remmintan.mods.minefortress.networking.helpers.FortressChannelNames
 import net.remmintan.mods.minefortress.networking.helpers.FortressServerNetworkHelper
 import net.remmintan.mods.minefortress.networking.s2c.ClientboundTaskExecutedPacket
+import org.minefortress.MineFortressConstants
 import java.util.*
 
 private const val PART_SIZE = 3
@@ -129,4 +130,6 @@ abstract class AbstractTask protected constructor(
         }
         return cursor.toImmutable()
     }
+
+    override fun estimateTimeRequired(): Double = (positions.size * (MineFortressConstants.ESTIMATED_PLACING_TIME + MineFortressConstants.ESTIMATED_BREAKING_TIME)) / assignedWorkers
 }

--- a/src/main/java/org/minefortress/tasks/AreaBlueprintTask.kt
+++ b/src/main/java/org/minefortress/tasks/AreaBlueprintTask.kt
@@ -22,6 +22,7 @@ import net.remmintan.mods.minefortress.core.utils.*
 import net.remmintan.mods.minefortress.networking.helpers.FortressChannelNames
 import net.remmintan.mods.minefortress.networking.helpers.FortressServerNetworkHelper
 import net.remmintan.mods.minefortress.networking.s2c.ClientboundTaskExecutedPacket
+import org.minefortress.MineFortressConstants
 import org.minefortress.tasks.block.info.BlockStateTaskBlockInfo
 import org.minefortress.tasks.block.info.DigTaskBlockInfo
 import java.util.*
@@ -83,6 +84,10 @@ class AreaBlueprintTask(
     override fun removeWorker() {
         assignedWorkers--
     }
+
+    // All buildings are build over land, with most blocks being air.
+    // So we assume that 9 out of every 10 blocks in selection are air.
+    override fun estimateTimeRequired(): Double = (totalManualBlocks * (MineFortressConstants.ESTIMATED_PLACING_TIME + MineFortressConstants.ESTIMATED_BREAKING_TIME * 0.1)) / assignedWorkers
 
     override fun getNextBlock(): ITaskBlockInfo? {
         return blocksQueue.poll()

--- a/src/main/java/org/minefortress/tasks/CutTreesTask.kt
+++ b/src/main/java/org/minefortress/tasks/CutTreesTask.kt
@@ -94,4 +94,7 @@ class CutTreesTask(private val trees: Map<BlockPos, TreeData>) : ITask {
     override fun removeWorker() {
         assignedWorkers--
     }
+
+    // 1.5 is wood breaking speed with wooden axe, taken from wiki.
+    override fun estimateTimeRequired(): Double = totalTreesCount * 1.5 / assignedWorkers
 }

--- a/src/main/java/org/minefortress/tasks/RoadsTask.kt
+++ b/src/main/java/org/minefortress/tasks/RoadsTask.kt
@@ -13,6 +13,7 @@ import net.remmintan.mods.minefortress.core.interfaces.tasks.ITaskPart
 import net.remmintan.mods.minefortress.networking.helpers.FortressChannelNames
 import net.remmintan.mods.minefortress.networking.helpers.FortressServerNetworkHelper
 import net.remmintan.mods.minefortress.networking.s2c.ClientboundTaskExecutedPacket
+import org.minefortress.MineFortressConstants
 import org.minefortress.tasks.block.info.ReplaceTaskBlockInfo
 import java.util.*
 import kotlin.math.max
@@ -129,4 +130,6 @@ class RoadsTask(override val positions: List<BlockPos>, private val item: Item) 
     override fun removeWorker() {
         assignedWorkers++
     }
+
+    override fun estimateTimeRequired(): Double = (positions.size * (MineFortressConstants.ESTIMATED_PLACING_TIME + MineFortressConstants.ESTIMATED_BREAKING_TIME)) / assignedWorkers
 }

--- a/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
+++ b/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
@@ -103,16 +103,17 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
     }
 
     private fun setPawnsToTask(task: IBaseTask, workers: List<IWorkerPawn>) {
+        val sortedWorkers = workers.sortedBy { task.pos.getSquaredDistance(it.pos) }
         when (task) {
             is ITask ->
-                for (worker in workers) {
+                for (worker in sortedWorkers) {
                     if (!task.hasAvailableParts() || !task.canTakeMoreWorkers()) break
                     task.addWorker()
                     worker.taskControl.setTask(task)
                 }
 
             is IAreaBasedTask ->
-                for (worker in workers) {
+                for (worker in sortedWorkers) {
                     if (!task.hasMoreBlocks() || !task.canTakeMoreWorkers()) break
                     task.addWorker()
                     worker.areaBasedTaskControl.setTask(task)

--- a/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
+++ b/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
@@ -22,6 +22,7 @@ import net.remmintan.mods.minefortress.networking.helpers.FortressChannelNames
 import net.remmintan.mods.minefortress.networking.helpers.FortressServerNetworkHelper
 import net.remmintan.mods.minefortress.networking.s2c.ClientboundTaskExecutedPacket
 import net.remmintan.mods.minefortress.networking.s2c.S2CAddClientTaskPacket
+import org.minefortress.MineFortressConstants
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -103,20 +104,18 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
     }
 
     private fun setPawnsToTask(task: IBaseTask, workers: List<IWorkerPawn>) {
-        val sortedWorkers = workers.sortedBy { task.pos.getSquaredDistance(it.pos) }
+        val sortedWorkers = workers.filter { !it.taskQueueControl.isOnTask(task) }.sortedBy { it.taskQueueControl.estimateTimeRequired() + (it.taskQueueControl.lastPos.getSquaredDistance(task.pos)) / MineFortressConstants.ESTIMATED_RUNNING_SPEED }
         when (task) {
             is ITask ->
                 for (worker in sortedWorkers) {
                     if (!task.hasAvailableParts() || !task.canTakeMoreWorkers()) break
-                    task.addWorker()
-                    worker.taskControl.setTask(task)
+                    worker.taskQueueControl.addTask(task)
                 }
 
             is IAreaBasedTask ->
                 for (worker in sortedWorkers) {
                     if (!task.hasMoreBlocks() || !task.canTakeMoreWorkers()) break
-                    task.addWorker()
-                    worker.areaBasedTaskControl.setTask(task)
+                    worker.taskQueueControl.addTask(task)
                 }
 
             else -> error("Wrong task class")
@@ -212,7 +211,7 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
                 .filterNotNull()
                 .filter { it is IWorkerPawn }
                 .map { it as IWorkerPawn }
-                .filter { !it.taskControl.isDoingEverydayTasks }
+                .filter { !it.taskQueueControl.isDoingEverydayTasks }
                 .toList()
         }
     }


### PR DESCRIPTION
Added estimation of time required for completion to `IBaseTask` interface, as well as computations of this estimation inside the tasks. (they're not very accurate, since currently don't even use data from the world, but only amount of blocks placed/destroyed for estimation)

Pawn now can have multiple tasks assigned to it. This allows, when pawns are selected automatically, to select pawns not based only on their distance, but also on the time it will take for them to complete all the previous work. This logic is added through new `TaskQueueControl`.

Move `cooldown` and `doingEverydayTasks` logic from `TaskControl` and `AreaBasedTaskControl` into `TaskQueueControl`, adds `TaskQueueControl` into `Colonist`, and change `ServerTaskManager` to use information from `TaskQueueControl` to sort pawns for tasks.

Where appropriate, `TaskControl` and `AreaBasedTaskControl` usage was replaced with `TaskQueueControl`.

Finally, values like cooldown on tasks, which I noticed along the way, were moved up into constants.

The following behaviors should be fixed after this pull request:
+ When selecting pawns for one task, then selecting same pawns for another while they're doing the first task, the first task would get abandoned and linger on until the restart. This is likely caused by `setTask` being called on pawns currently locked in tasks, which logic inside `ServerTaskManager::addTask` (used when there are pawns selected) doesn't account for, so the task thinks those workers are still assigned to it.
+ Pawns seemingly with no tasks not doing the work up close since cooldown on building (1 second) prevents them from taking new tasks, which could seem like a bug. Now they can be marked for work despite cooldown, and actually do the task later.
+ Partially fixes far-away constructions bringing new and new pawns from fireplace instead of reusing pawns that are few seconds away from doing the work, but locked in tasks.
+ Tasks from `AreaBasedTaskControl` (Blueprints) and `TaskControl` (other building/destruction work) had separate cooldowns, which would add up to the perception that cooldown is a bug. Now, cooldown is unified inside `TaskQueueControl`.
+ I don't know if this caused problems, but in `ReturnToFireGoal`, `SleepOnTheBedGoal`, `WanderAroundTheFortressGoal`, instead of checking for both `AreaBasedTaskControl` and `TaskControl` having any task, only later was checked. Whether this caused any issues while building blueprints is yet to be seen, but now they check `TaskQueueControl`.

In the future, this change would allow stopping selected pawns being unselected after each assigned task in build mode, bringing parity with combat mode.