### PR TITLE
Fix tasks getting stuck if its pawns were selected again for some other task before completion

### DIFF
--- a/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
+++ b/src/main/java/org/minefortress/tasks/ServerTaskManager.kt
@@ -102,11 +102,20 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
         }
     }
 
+    private fun freeWorkerUp(worker: IWorkerPawn) {
+        if (worker.taskControl.hasTask()) {
+            worker.taskControl.fail()
+        }
+        if (worker.areaBasedTaskControl.hasTask()) {
+            worker.areaBasedTaskControl.reset()
+        }
+    }
     private fun setPawnsToTask(task: IBaseTask, workers: List<IWorkerPawn>) {
         when (task) {
             is ITask ->
                 for (worker in workers) {
                     if (!task.hasAvailableParts() || !task.canTakeMoreWorkers()) break
+                    freeWorkerUp(worker)
                     task.addWorker()
                     worker.taskControl.setTask(task)
                 }
@@ -114,6 +123,7 @@ class ServerTaskManager(private val server: MinecraftServer, fortressPos: BlockP
             is IAreaBasedTask ->
                 for (worker in workers) {
                     if (!task.hasMoreBlocks() || !task.canTakeMoreWorkers()) break
+                    freeWorkerUp(worker)
                     task.addWorker()
                     worker.areaBasedTaskControl.setTask(task)
                 }


### PR DESCRIPTION
If you manually select pawns that are assigned to some task (whether manually or automatically), then assign those pawns to another task while the first one is still in progress, then the first task will be put in invalid state, thinking those pawns are still on it, and linger on until world restart or being canceled.

To fix this, `ServerTaskManager::setPawnsToTask` will now fail previous tasks first, then assign pawns to the new task.

Under the new behavior, any new building projects override the old.