### PR TITLE
Speed up switching between the tasks for pawns

### DIFF
--- a/src/main/java/org/minefortress/entity/ai/controls/AreaBasedTaskControl.kt
+++ b/src/main/java/org/minefortress/entity/ai/controls/AreaBasedTaskControl.kt
@@ -18,7 +18,7 @@ class AreaBasedTaskControl(private val pawn: Colonist) : IAreaBasedTaskControl {
         this.task = task
     }
 
-    override fun hasTask() = task != null && task?.notCancelled() ?: false
+    override fun hasTask() = task != null && task?.notCancelled() ?: false && (task?.hasMoreBlocks() ?: false || currentBlock != null)
     override fun hasMoreBlocks() = task
         ?.let { it.notCancelled() && it.hasMoreBlocks() }
         ?: false

--- a/src/main/java/org/minefortress/entity/ai/controls/TaskControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/TaskControl.java
@@ -54,7 +54,7 @@ public class TaskControl implements ITaskControl {
 
     @Override
     public boolean hasTask() {
-        return task != null && task.notCancelled();
+        return task != null && task.notCancelled() && (hasTaskPart() || task.hasAvailableParts());
     }
 
     @Override


### PR DESCRIPTION
Speeds up switching between the tasks for pawns by making `hasTask()` in both of task-related controls consider the possibility, that all assigned parts of a task were already done by a pawn.

Previously, even when pawn done all its work related to the task, it would still wait for full task completion, which isn't strictly necessary. Now, pawn can switch to the next task right after finishing all its part in the task.