### PR TITLE
Add `fortress archers spawn <num>` command

### DIFF
--- a/src/core/java/net/remmintan/mods/minefortress/core/interfaces/combat/IServerFightManager.java
+++ b/src/core/java/net/remmintan/mods/minefortress/core/interfaces/combat/IServerFightManager.java
@@ -10,6 +10,7 @@ import net.remmintan.mods.minefortress.core.interfaces.server.IWritableManager;
 
 public interface IServerFightManager extends IServerManager, ISyncableServerManager, IWritableManager, ITickableManager {
     void spawnDebugWarriors(int num, ServerPlayerEntity player);
+    void spawnDebugArchers(int num, ServerPlayerEntity player);
     void setCurrentTarget(BlockPos pos, ServerWorld world);
     void attractWarriorsToCampfire();
 

--- a/src/main/java/org/minefortress/commands/ArchersCommand.java
+++ b/src/main/java/org/minefortress/commands/ArchersCommand.java
@@ -1,0 +1,34 @@
+package org.minefortress.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import net.minecraft.server.command.ServerCommandSource;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class ArchersCommand extends MineFortressCommand {
+
+    /*
+    // fortress archers spawn <num> <blockPos>
+     */
+    @Override
+    public void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(
+            literal("fortress")
+                .then(literal("archers")
+                    .then(literal("spawn")
+                        .then(argument("num", IntegerArgumentType.integer())
+                            .executes(context -> {
+                                final var num = IntegerArgumentType.getInteger(context, "num");
+                                final var fightManager = getServerManagersProvider(context).getFightManager();
+                                fightManager.spawnDebugArchers(num, context.getSource().getPlayer());
+
+                                return 1;
+                            })
+                        )
+                    )
+                )
+        );
+    }
+}

--- a/src/main/java/org/minefortress/commands/CommandsManager.java
+++ b/src/main/java/org/minefortress/commands/CommandsManager.java
@@ -11,7 +11,8 @@ public class CommandsManager {
             new DebugItemsCommand(),
             new DebugPawnsCommand(),
             new SpawnPawnsCommand(),
-            new WarriorsCommand()
+            new WarriorsCommand(),
+            new ArchersCommand()
     );
 
     private CommandsManager(){}

--- a/src/main/java/org/minefortress/fight/ServerFightManager.java
+++ b/src/main/java/org/minefortress/fight/ServerFightManager.java
@@ -37,6 +37,11 @@ public class ServerFightManager implements IServerFightManager {
     }
 
     @Override
+    public void spawnDebugArchers(int num, ServerPlayerEntity player) {
+        serverFortressManager.spawnDebugEntitiesAroundCampfire(FortressEntities.ARCHER_PAWN_ENTITY_TYPE, num, player);
+    }
+
+    @Override
     public void setCurrentTarget(BlockPos pos, ServerWorld world) {
         keepTrackOfOldTarget(world);
         oldTarget = FortressEntities.NAVIGATION_TARGET_ENTITY_TYPE.spawn(world, pos.up(), SpawnReason.EVENT);


### PR DESCRIPTION
Add `fortress archers spawn <num>` command in same fashion as `fortress warriors spawn <num>` and `fortress pawns <num>`. Currently, I found no way to get archers on master, so this command is necessary to allow checking any archer-related behavior for now.