### PR TITLE
Improve archers

### DIFF
--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -17,9 +17,7 @@ import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.IProfessio
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.IWarrior;
 import org.minefortress.entity.ai.goal.EatGoal;
 import org.minefortress.entity.ai.goal.SelectTargetToAttackGoal;
-import org.minefortress.entity.ai.goal.warrior.FollowLivingEntityGoal;
-import org.minefortress.entity.ai.goal.warrior.MoveToBlockGoal;
-import org.minefortress.entity.ai.goal.warrior.RangedAttackGoal;
+import org.minefortress.entity.ai.goal.warrior.*;
 
 public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMob, IProfessional {
 
@@ -31,6 +29,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
     protected void initGoals() {
         super.initGoals();
         this.goalSelector.add(1, new RangedAttackGoal(this));
+        this.goalSelector.add(1, new BackAwayGoal(this, 8.0));
         this.goalSelector.add(2, new MoveToBlockGoal(this));
         this.goalSelector.add(2, new FollowLivingEntityGoal(this));
         this.goalSelector.add(3, new EatGoal(this));

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -67,7 +67,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
         double f = target.getZ() - this.getZ();
         double g = Math.sqrt(d * d + f * f);
         persistentProjectileEntity.setVelocity(d, e + g * 0.20000000298023224, f, 1.6F, (float)(14 - this.getWorld().getDifficulty().getId() * 4));
-        this.playSound(SoundEvents.ENTITY_SKELETON_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
+        this.playSound(SoundEvents.ENTITY_SKELETON_SHOOT, 1.0F, 2F);
         this.getWorld().spawnEntity(persistentProjectileEntity);
     }
 

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -75,8 +75,8 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
         d += target.getVelocity().x * estimatedTime;
         f += target.getVelocity().z * estimatedTime;
 
-        persistentProjectileEntity.setVelocity(d, e + g * 0.20000000298023224, f, 1.6F, (float)(14 - this.getWorld().getDifficulty().getId() * 4));
-        this.playSound(SoundEvents.ENTITY_ARROW_SHOOT, 1.0F, 2F);
+        persistentProjectileEntity.setVelocity(d, e + g * 0.20000000298023224, f, 1.6F, 2F);
+        this.playSound(SoundEvents.ENTITY_ARROW_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
         this.getWorld().spawnEntity(persistentProjectileEntity);
     }
 

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -62,6 +62,8 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
     public void shootAt(LivingEntity target, float pullProgress) {
         final var itemStack = new ItemStack(Items.ARROW);
         final var persistentProjectileEntity = ProjectileUtil.createArrowProjectile(this, itemStack, pullProgress);
+        if(pullProgress >= 1.1)
+            persistentProjectileEntity.setCritical(true);
         double d = target.getX() - this.getX(); // Difference by X
         double e = target.getBodyY(1.0 / 3.0) - persistentProjectileEntity.getY();
         double f = target.getZ() - this.getZ(); // Difference by Z

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -24,7 +24,7 @@ import org.minefortress.entity.ai.goal.warrior.RangedAttackGoal;
 public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMob, IProfessional {
 
     public ArcherPawn(EntityType<? extends BasePawnEntity> entityType, World world) {
-        super(entityType, world, false);
+        super(entityType, world, true);
     }
 
     @Override

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -62,10 +62,19 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
     public void shootAt(LivingEntity target, float pullProgress) {
         final var itemStack = new ItemStack(Items.ARROW);
         final var persistentProjectileEntity = ProjectileUtil.createArrowProjectile(this, itemStack, pullProgress);
-        double d = target.getX() - this.getX();
-        double e = target.getBodyY(0.3333333333333333) - persistentProjectileEntity.getY();
-        double f = target.getZ() - this.getZ();
+        double d = target.getX() - this.getX(); // Difference by X
+        double e = target.getBodyY(1.0 / 3.0) - persistentProjectileEntity.getY();
+        double f = target.getZ() - this.getZ(); // Difference by Z
         double g = Math.sqrt(d * d + f * f);
+
+        // Estimate time it will take for arrow to get to target.
+        double estimatedDistance = Math.sqrt(persistentProjectileEntity.getPos().squaredDistanceTo(target.getPos()));
+        double estimatedTime = estimatedDistance / 1.6f; // In ticks.
+
+        // Adjust vector for predicted position.
+        d += target.getVelocity().x * estimatedTime;
+        f += target.getVelocity().z * estimatedTime;
+
         persistentProjectileEntity.setVelocity(d, e + g * 0.20000000298023224, f, 1.6F, (float)(14 - this.getWorld().getDifficulty().getId() * 4));
         this.playSound(SoundEvents.ENTITY_SKELETON_SHOOT, 1.0F, 2F);
         this.getWorld().spawnEntity(persistentProjectileEntity);

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -29,7 +29,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
     protected void initGoals() {
         super.initGoals();
         this.goalSelector.add(1, new RangedAttackGoal(this));
-        this.goalSelector.add(1, new BackAwayGoal(this, 8.0));
+        this.goalSelector.add(1, new BackAwayGoal(this, 5.0));
         this.goalSelector.add(2, new MoveToBlockGoal(this));
         this.goalSelector.add(2, new FollowLivingEntityGoal(this));
         this.goalSelector.add(3, new EatGoal(this));

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -41,7 +41,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
     }
 
     private boolean canAttack(LivingEntity it) {
-        return it.isAlive() && (it instanceof HostileEntity || it.equals(getAttackTarget()));
+        return it.isAlive() && (it instanceof HostileEntity || it.equals(getAttackTarget())) && getVisibilityCache().canSee(it);
     }
 
     public static DefaultAttributeContainer.Builder createAttributes() {

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -76,7 +76,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
         f += target.getVelocity().z * estimatedTime;
 
         persistentProjectileEntity.setVelocity(d, e + g * 0.20000000298023224, f, 1.6F, (float)(14 - this.getWorld().getDifficulty().getId() * 4));
-        this.playSound(SoundEvents.ENTITY_SKELETON_SHOOT, 1.0F, 2F);
+        this.playSound(SoundEvents.ENTITY_ARROW_SHOOT, 1.0F, 2F);
         this.getWorld().spawnEntity(persistentProjectileEntity);
     }
 

--- a/src/main/java/org/minefortress/entity/ArcherPawn.java
+++ b/src/main/java/org/minefortress/entity/ArcherPawn.java
@@ -15,6 +15,7 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.world.World;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.IProfessional;
 import net.remmintan.mods.minefortress.core.interfaces.entities.pawns.IWarrior;
+import org.minefortress.entity.ai.goal.EatGoal;
 import org.minefortress.entity.ai.goal.SelectTargetToAttackGoal;
 import org.minefortress.entity.ai.goal.warrior.FollowLivingEntityGoal;
 import org.minefortress.entity.ai.goal.warrior.MoveToBlockGoal;
@@ -32,6 +33,7 @@ public class ArcherPawn extends TargetedPawn implements IWarrior, RangedAttackMo
         this.goalSelector.add(1, new RangedAttackGoal(this));
         this.goalSelector.add(2, new MoveToBlockGoal(this));
         this.goalSelector.add(2, new FollowLivingEntityGoal(this));
+        this.goalSelector.add(3, new EatGoal(this));
         this.goalSelector.add(9, new LookAtEntityGoal(this, LivingEntity.class, 4f));
         this.goalSelector.add(10, new LookAroundGoal(this));
 

--- a/src/main/java/org/minefortress/entity/BaritonableEntity.java
+++ b/src/main/java/org/minefortress/entity/BaritonableEntity.java
@@ -2,6 +2,7 @@ package org.minefortress.entity;
 
 import baritone.api.minefortress.IMinefortressEntity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.data.TrackedData;
 import net.minecraft.entity.data.TrackedDataHandlerRegistry;
@@ -59,5 +60,13 @@ public abstract class BaritonableEntity extends PathAwareEntity implements IMine
         }
 
         super.onTrackedDataSet(data);
+    }
+
+    @Override
+    public void tickMovement() {
+        super.tickMovement();
+        setMovementSpeed((float)this.getAttributeValue(EntityAttributes.GENERIC_MOVEMENT_SPEED));
+        if (isUsingItem() && !hasVehicle())
+            setMovementSpeed(getMovementSpeed() / 5.0F);
     }
 }

--- a/src/main/java/org/minefortress/entity/ai/controls/BaritoneMoveControl.java
+++ b/src/main/java/org/minefortress/entity/ai/controls/BaritoneMoveControl.java
@@ -45,7 +45,6 @@ public class BaritoneMoveControl implements IBaritoneMoveControl {
     public void moveTo(@NotNull BlockPos pos) {
         this.reset(true);
         this.updateReachRange(false);
-        this.entity.setMovementSpeed((float)this.entity.getAttributeValue(EntityAttributes.GENERIC_MOVEMENT_SPEED));
         this.moveTarget = pos;
         final var goal = new GoalNear(pos, (int) Math.floor(currentReachRange));
         baritone.getCustomGoalProcess().setGoalAndPath(goal);
@@ -57,7 +56,6 @@ public class BaritoneMoveControl implements IBaritoneMoveControl {
         this.updateReachRange(true);
         this.baritone.settings().followRadius.set((int)Math.floor(currentReachRange));
         this.followTarget = entity;
-        this.entity.setMovementSpeed((float)this.entity.getAttributeValue(EntityAttributes.GENERIC_MOVEMENT_SPEED));
         baritone.getFollowProcess().follow(it -> it.equals(entity));
     }
 

--- a/src/main/java/org/minefortress/entity/ai/goal/EatGoal.kt
+++ b/src/main/java/org/minefortress/entity/ai/goal/EatGoal.kt
@@ -9,7 +9,7 @@ import org.minefortress.entity.HungryEntity
 
 class EatGoal(private val entity: HungryEntity) : Goal() {
     override fun canStart(): Boolean {
-        return eatControl.isHungry && foodManager.hasFood()
+        return eatControl.isHungry && foodManager.hasFood() && entity.target == null
     }
 
     override fun start() {

--- a/src/main/java/org/minefortress/entity/ai/goal/SelectTargetToAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/SelectTargetToAttackGoal.java
@@ -25,6 +25,7 @@ public final class SelectTargetToAttackGoal extends TrackTargetGoal {
     @Nullable
     private LivingEntity targetEntity;
     private final TargetPredicate targetPredicate;
+    private int cooldown;
 
     public SelectTargetToAttackGoal(MobEntity mob, @NotNull Predicate<LivingEntity> targetPredicate) {
         super(mob, false, true);
@@ -45,7 +46,18 @@ public final class SelectTargetToAttackGoal extends TrackTargetGoal {
     @Override
     public void start() {
         this.mob.setTarget(this.targetEntity);
+        cooldown = mob.getRandom().nextBetween(15, 26);
         super.start();
+    }
+
+    @Override
+    public void tick() {
+        if(cooldown == 0) {
+            this.findClosestTarget();
+            this.mob.setTarget(this.targetEntity);
+            cooldown = mob.getRandom().nextBetween(15, 26);
+        }
+        --cooldown;
     }
 
     private Box getSearchBox(double distance) {

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
@@ -1,12 +1,15 @@
 package org.minefortress.entity.ai.goal.warrior;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 import org.minefortress.entity.BasePawnEntity;
-
 import java.util.EnumSet;
 
 public class BackAwayGoal extends AttackGoal {
     private final double keptSquaredDistance;
+
     public BackAwayGoal(BasePawnEntity pawn, double keptDistance) {
         super(pawn);
         this.keptSquaredDistance = keptDistance * keptDistance;
@@ -23,7 +26,6 @@ public class BackAwayGoal extends AttackGoal {
                 // if the mob comes from downward direction.
                 // So archers will not jump off from towers and walls.
                 targetPosition = new Vec3d(targetPosition.x, targetPosition.y * 4, targetPosition.z);
-
             return pawn.getPos().squaredDistanceTo(targetPosition);
         }).orElse(Double.POSITIVE_INFINITY);
     }
@@ -33,19 +35,58 @@ public class BackAwayGoal extends AttackGoal {
         return super.canStart() && getSquaredDistance() < keptSquaredDistance;
     }
 
+    // Check if the pawn would fall off at the given position
+    private boolean isLocationFallSafe(Vec3d position) {
+        World world = pawn.getWorld();
+        BlockPos blockPos = new BlockPos((int)position.x, (int)position.y, (int)position.z);
+
+        // Check if there's a solid block beneath the pawn
+        BlockPos beneathPos = blockPos.down();
+        BlockState beneathState = world.getBlockState(beneathPos);
+
+        // If there's no solid block beneath, the pawn would fall
+        return beneathState.isSolidBlock(world, beneathPos);
+    }
+
+    // Find a safe direction to move
+    private Vec3d findSafeDirection(Vec3d away) {
+        // Try the original direction first
+        Vec3d newPos = pawn.getPos().add(away.normalize().multiply(pawn.getMovementSpeed()));
+        if (isLocationFallSafe(newPos)) {
+            return away;
+        }
+
+        // Try moving to the right
+        Vec3d right = new Vec3d(-away.z, 0, away.x).normalize();
+        newPos = pawn.getPos().add(right.multiply(pawn.getMovementSpeed()));
+        if (isLocationFallSafe(newPos)) {
+            return right;
+        }
+
+        // Try moving to the left
+        Vec3d left = new Vec3d(away.z, 0, -away.x).normalize();
+        newPos = pawn.getPos().add(left.multiply(pawn.getMovementSpeed()));
+        if (isLocationFallSafe(newPos)) {
+            return left;
+        }
+
+        // If all directions would lead to falling, don't move
+        return Vec3d.ZERO;
+    }
+
     @Override
     public void tick() {
         getTarget().ifPresent(target -> {
             var away = pawn.getPos().subtract(target.getPos());
             // What do you mean archers shouldn't escape from targets into the sky?
             away = new Vec3d(away.x, 0.0, away.z);
-            away = away.normalize().multiply(pawn.getMovementSpeed());
-            pawn.addVelocity(away);
-        });
-    }
+            away = away.normalize();
 
-    @Override
-    public boolean shouldContinue() {
-        return super.shouldContinue() && getSquaredDistance() < keptSquaredDistance;
+            // Find a safe direction to move
+            Vec3d safeDirection = findSafeDirection(away);
+            safeDirection = safeDirection.multiply(pawn.getMovementSpeed());
+
+            pawn.setVelocity(safeDirection);
+        });
     }
 }

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
@@ -1,0 +1,51 @@
+package org.minefortress.entity.ai.goal.warrior;
+
+import net.minecraft.util.math.Vec3d;
+import org.minefortress.entity.BasePawnEntity;
+
+import java.util.EnumSet;
+
+public class BackAwayGoal extends AttackGoal {
+    private final double keptSquaredDistance;
+    public BackAwayGoal(BasePawnEntity pawn, double keptDistance) {
+        super(pawn);
+        this.keptSquaredDistance = keptDistance * keptDistance;
+        this.setControls(EnumSet.of(Control.MOVE));
+    }
+
+    private double getSquaredDistance() {
+        return getTarget().map(target -> {
+            Vec3d targetPosition = target.getPos();
+            // If you have the high ground...
+            if(pawn.getPos().y > targetPosition.y)
+                // ...you better not to lose it.
+                // This will make archers be less inclined to back away,
+                // if the mob comes from downward direction.
+                // So archers will not jump off from towers and walls.
+                targetPosition = new Vec3d(targetPosition.x, targetPosition.y * 4, targetPosition.z);
+
+            return pawn.getPos().squaredDistanceTo(targetPosition);
+        }).orElse(Double.POSITIVE_INFINITY);
+    }
+
+    @Override
+    public boolean canStart() {
+        return super.canStart() && getSquaredDistance() < keptSquaredDistance;
+    }
+
+    @Override
+    public void tick() {
+        getTarget().ifPresent(target -> {
+            var away = pawn.getPos().subtract(target.getPos());
+            // What do you mean archers shouldn't escape from targets into the sky?
+            away = new Vec3d(away.x, 0.0, away.z);
+            away = away.normalize().multiply(pawn.getMovementSpeed());
+            pawn.addVelocity(away);
+        });
+    }
+
+    @Override
+    public boolean shouldContinue() {
+        return super.shouldContinue() && getSquaredDistance() < keptSquaredDistance;
+    }
+}

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/BackAwayGoal.java
@@ -38,7 +38,10 @@ public class BackAwayGoal extends AttackGoal {
     // Check if the pawn would fall off at the given position
     private boolean isLocationFallSafe(Vec3d position) {
         World world = pawn.getWorld();
-        BlockPos blockPos = new BlockPos((int)position.x, (int)position.y, (int)position.z);
+        int x = (int) Math.floor(position.x);
+        int y = (int) Math.floor(position.y);
+        int z = (int) Math.floor(position.z);
+        BlockPos blockPos = new BlockPos(x, y, z);
 
         // Check if there's a solid block beneath the pawn
         BlockPos beneathPos = blockPos.down();

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/MoveToBlockGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/MoveToBlockGoal.java
@@ -40,6 +40,8 @@ public class MoveToBlockGoal extends Goal {
     @Override
     public void stop() {
         pawn.getFortressMoveControl().reset();
+        if(stillOnTheSameTarget())
+            pawn.resetTargets();
         target = null;
     }
 

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -44,7 +44,16 @@ public class RangedAttackGoal extends AttackGoal {
                 --this.targetSeeingTicker;
             }
 
-            double distance = pawn.getPos().squaredDistanceTo(target.getPos());
+            Vec3d targetPosition = target.getPos();
+            // If you have the high ground...
+            if(pawn.getPos().y > targetPosition.y)
+                // ...you better not to lose it.
+                // This will make archers be less inclined to back away,
+                // if the mob comes from downward direction.
+                // So archers will not jump off from towers and walls.
+                targetPosition = new Vec3d(targetPosition.x, targetPosition.y * 4, targetPosition.z);
+
+            double distance = pawn.getPos().squaredDistanceTo(targetPosition);
 
             if (pawn.isUsingItem()) {
                 if (!visible && this.targetSeeingTicker < -60) {

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -5,10 +5,11 @@ import net.minecraft.entity.projectile.ProjectileUtil;
 import net.minecraft.item.BowItem;
 import net.minecraft.item.Items;
 import net.minecraft.item.ShieldItem;
+import net.minecraft.util.math.Vec3d;
 import org.minefortress.entity.BasePawnEntity;
 
 public class RangedAttackGoal extends AttackGoal {
-
+    private final static double BACKING_AWAY_SPEED = 0.065F; // See https://minecraft.wiki/w/Sneaking#Effects
     private int targetSeeingTicker = 0;
     private int longShootingCooldown;
     private int shortShootingCooldown;
@@ -42,6 +43,8 @@ public class RangedAttackGoal extends AttackGoal {
                 --this.targetSeeingTicker;
             }
 
+            double distance = pawn.getPos().squaredDistanceTo(target.getPos());
+
             if (pawn.isUsingItem()) {
                 if (!visible && this.targetSeeingTicker < -60) {
                     pawn.clearActiveItem();
@@ -50,7 +53,6 @@ public class RangedAttackGoal extends AttackGoal {
 
                     boolean heDroppedHisShield = target.getOffHandStack().getItem() instanceof ShieldItem && !target.isBlocking();
 
-                    double distance = pawn.getPos().squaredDistanceTo(target.getPos());
                     boolean shortAttack = (distance < 5.0 * 5.0 || heDroppedHisShield) && i >= shortShootingCooldown;
                     boolean longAttack = i >= longShootingCooldown;
                     if (shortAttack || longAttack) {
@@ -67,6 +69,14 @@ public class RangedAttackGoal extends AttackGoal {
                 }
             } else if (this.targetSeeingTicker >= -60) {
                 pawn.setCurrentHand(ProjectileUtil.getHandPossiblyHolding(pawn, Items.BOW));
+            }
+
+            if (distance < 5.0 * 5.0) {
+                var away = pawn.getPos().subtract(target.getPos());
+                // What do you mean archers shouldn't escape from targets into the sky?
+                away = new Vec3d(away.x, 0.0, away.z);
+                away = away.normalize().multiply(BACKING_AWAY_SPEED);
+                pawn.setVelocity(away);
             }
         });
     }

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -10,6 +10,7 @@ import org.minefortress.entity.BasePawnEntity;
 
 public class RangedAttackGoal extends AttackGoal {
     private int targetSeeingTicker = 0;
+    private int relaxCooldown;
     private int longShootingCooldown;
     private int shortShootingCooldown;
 
@@ -21,6 +22,7 @@ public class RangedAttackGoal extends AttackGoal {
     public void start() {
         super.start();
         pawn.putItemInHand(Items.BOW);
+        relaxCooldown = pawn.getRandom().nextBetween(5, 11);
         longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
         shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
     }
@@ -53,7 +55,7 @@ public class RangedAttackGoal extends AttackGoal {
                     boolean heDroppedHisShield = target.getOffHandStack().getItem() instanceof ShieldItem && !target.isBlocking();
 
                     boolean shortAttack = (distance < 5.0 * 5.0 || heDroppedHisShield) && i >= shortShootingCooldown;
-                    boolean longAttack = i >= longShootingCooldown;
+                    boolean longAttack = i >= longShootingCooldown && relaxCooldown < 1;
                     if (shortAttack || longAttack) {
                         pawn.clearActiveItem();
                         float progress = BowItem.getPullProgress(i);
@@ -62,11 +64,12 @@ public class RangedAttackGoal extends AttackGoal {
                         if(i >= 22)
                             progress = 1.1F;
                         ((RangedAttackMob)pawn).shootAt(target, progress);
+                        relaxCooldown = pawn.getRandom().nextBetween(5, 11);
                         longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
                         shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
                     }
                 }
-            } else if (this.targetSeeingTicker >= -60) {
+            } else if (--this.relaxCooldown <= 0 && this.targetSeeingTicker >= -60) {
                 pawn.setCurrentHand(ProjectileUtil.getHandPossiblyHolding(pawn, Items.BOW));
             }
 

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -9,7 +9,6 @@ import net.minecraft.util.math.Vec3d;
 import org.minefortress.entity.BasePawnEntity;
 
 public class RangedAttackGoal extends AttackGoal {
-    private final static double BACKING_AWAY_SPEED = 0.065F; // See https://minecraft.wiki/w/Sneaking#Effects
     private int targetSeeingTicker = 0;
     private int longShootingCooldown;
     private int shortShootingCooldown;
@@ -75,7 +74,7 @@ public class RangedAttackGoal extends AttackGoal {
                 var away = pawn.getPos().subtract(target.getPos());
                 // What do you mean archers shouldn't escape from targets into the sky?
                 away = new Vec3d(away.x, 0.0, away.z);
-                away = away.normalize().multiply(BACKING_AWAY_SPEED);
+                away = away.normalize().multiply(pawn.getMovementSpeed());
                 pawn.setVelocity(away);
             }
         });

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.projectile.ProjectileUtil;
 import net.minecraft.item.BowItem;
 import net.minecraft.item.Items;
+import net.minecraft.item.ShieldItem;
 import org.minefortress.entity.BasePawnEntity;
 
 public class RangedAttackGoal extends AttackGoal {
@@ -12,7 +13,8 @@ public class RangedAttackGoal extends AttackGoal {
 
     private int targetSeeingTicker = 0;
     private int cooldown = 0;
-    private int plannedTimeToShoot;
+    private int longShootingCooldown;
+    private int shortShootingCooldown;
 
     public RangedAttackGoal(BasePawnEntity pawn) {
         super(pawn);
@@ -22,7 +24,8 @@ public class RangedAttackGoal extends AttackGoal {
     public void start() {
         super.start();
         pawn.putItemInHand(Items.BOW);
-        plannedTimeToShoot = pawn.getRandom().nextBetween(20, 35);
+        longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
+        shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
     }
 
     @Override
@@ -47,7 +50,13 @@ public class RangedAttackGoal extends AttackGoal {
                     pawn.clearActiveItem();
                 } else if (visible) {
                     int i = pawn.getItemUseTime();
-                    if (i >= plannedTimeToShoot) {
+
+                    boolean heDroppedHisShield = target.getOffHandStack().getItem() instanceof ShieldItem && !target.isBlocking();
+
+                    double distance = pawn.getPos().squaredDistanceTo(target.getPos());
+                    boolean shortAttack = (distance < 5.0 * 5.0 || heDroppedHisShield) && i >= shortShootingCooldown;
+                    boolean longAttack = i >= longShootingCooldown;
+                    if (shortAttack || longAttack) {
                         pawn.clearActiveItem();
                         float progress = BowItem.getPullProgress(i);
                         // Use special value for critical hits.
@@ -56,7 +65,8 @@ public class RangedAttackGoal extends AttackGoal {
                             progress = 1.1F;
                         ((RangedAttackMob)pawn).shootAt(target, progress);
                         this.cooldown = INTERVAL;
-                        plannedTimeToShoot = pawn.getRandom().nextBetween(20, 35);
+                        longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
+                        shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
                     }
                 }
             } else if (--this.cooldown <= 0 && this.targetSeeingTicker >= -60) {

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -13,18 +13,25 @@ public class RangedAttackGoal extends AttackGoal {
     private int relaxCooldown;
     private int longShootingCooldown;
     private int shortShootingCooldown;
+    private boolean isCurrentShotCritical;
 
     public RangedAttackGoal(BasePawnEntity pawn) {
         super(pawn);
+    }
+
+    private void updateCooldowns() {
+        var random = pawn.getRandom();
+        relaxCooldown = random.nextBetween(5, 11);
+        longShootingCooldown = random.nextBetween(22, 35);
+        shortShootingCooldown = random.nextBetween(10, 15);
+        isCurrentShotCritical = random.nextFloat() > 0.6F;
     }
 
     @Override
     public void start() {
         super.start();
         pawn.putItemInHand(Items.BOW);
-        relaxCooldown = pawn.getRandom().nextBetween(5, 11);
-        longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
-        shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
+        updateCooldowns();
     }
 
     @Override
@@ -64,7 +71,9 @@ public class RangedAttackGoal extends AttackGoal {
                     boolean heDroppedHisShield = target.getOffHandStack().getItem() instanceof ShieldItem && !target.isBlocking();
 
                     boolean shortAttack = (distance < 5.0 * 5.0 || heDroppedHisShield) && i >= shortShootingCooldown;
-                    boolean longAttack = i >= longShootingCooldown && relaxCooldown < 1;
+                    boolean nonCriticalAttack = (!isCurrentShotCritical && i >= 20);
+                    boolean criticalAttack = i >= longShootingCooldown;
+                    boolean longAttack = (nonCriticalAttack || criticalAttack) && relaxCooldown < 1;
                     if (shortAttack || longAttack) {
                         pawn.clearActiveItem();
                         float progress = BowItem.getPullProgress(i);
@@ -73,9 +82,7 @@ public class RangedAttackGoal extends AttackGoal {
                         if(i >= 22)
                             progress = 1.1F;
                         ((RangedAttackMob)pawn).shootAt(target, progress);
-                        relaxCooldown = pawn.getRandom().nextBetween(5, 11);
-                        longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
-                        shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
+                        updateCooldowns();
                     }
                 }
             } else if (--this.relaxCooldown <= 0 && this.targetSeeingTicker >= -60) {
@@ -95,6 +102,7 @@ public class RangedAttackGoal extends AttackGoal {
     @Override
     public void stop() {
         super.stop();
+        this.relaxCooldown = 0;
         this.targetSeeingTicker = 0;
         if(pawn.isItemInHand(Items.BOW)) {
             pawn.clearActiveItem();

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -94,7 +94,7 @@ public class RangedAttackGoal extends AttackGoal {
                 // What do you mean archers shouldn't escape from targets into the sky?
                 away = new Vec3d(away.x, 0.0, away.z);
                 away = away.normalize().multiply(pawn.getMovementSpeed());
-                pawn.setVelocity(away);
+                pawn.addVelocity(away);
             }
         });
     }

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -73,7 +73,7 @@ public class RangedAttackGoal extends AttackGoal {
                 pawn.setCurrentHand(ProjectileUtil.getHandPossiblyHolding(pawn, Items.BOW));
             }
 
-            if (distance < 5.0 * 5.0) {
+            if (distance < 8.0 * 8.0) {
                 var away = pawn.getPos().subtract(target.getPos());
                 // What do you mean archers shouldn't escape from targets into the sky?
                 away = new Vec3d(away.x, 0.0, away.z);

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -12,6 +12,7 @@ public class RangedAttackGoal extends AttackGoal {
 
     private int targetSeeingTicker = 0;
     private int cooldown = 0;
+    private int plannedTimeToShoot;
 
     public RangedAttackGoal(BasePawnEntity pawn) {
         super(pawn);
@@ -21,6 +22,7 @@ public class RangedAttackGoal extends AttackGoal {
     public void start() {
         super.start();
         pawn.putItemInHand(Items.BOW);
+        plannedTimeToShoot = pawn.getRandom().nextBetween(20, 35);
     }
 
     @Override
@@ -45,10 +47,16 @@ public class RangedAttackGoal extends AttackGoal {
                     pawn.clearActiveItem();
                 } else if (visible) {
                     int i = pawn.getItemUseTime();
-                    if (i >= 20) {
+                    if (i >= plannedTimeToShoot) {
                         pawn.clearActiveItem();
-                        ((RangedAttackMob)pawn).shootAt(target, BowItem.getPullProgress(i));
+                        float progress = BowItem.getPullProgress(i);
+                        // Use special value for critical hits.
+                        // Sadly, this seems like an abuse of `RangedAttackMob` interface.
+                        if(i >= 22)
+                            progress = 1.1F;
+                        ((RangedAttackMob)pawn).shootAt(target, progress);
                         this.cooldown = INTERVAL;
+                        plannedTimeToShoot = pawn.getRandom().nextBetween(20, 35);
                     }
                 }
             } else if (--this.cooldown <= 0 && this.targetSeeingTicker >= -60) {

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -9,10 +9,7 @@ import org.minefortress.entity.BasePawnEntity;
 
 public class RangedAttackGoal extends AttackGoal {
 
-    private static final int INTERVAL = 20;
-
     private int targetSeeingTicker = 0;
-    private int cooldown = 0;
     private int longShootingCooldown;
     private int shortShootingCooldown;
 
@@ -64,12 +61,11 @@ public class RangedAttackGoal extends AttackGoal {
                         if(i >= 22)
                             progress = 1.1F;
                         ((RangedAttackMob)pawn).shootAt(target, progress);
-                        this.cooldown = INTERVAL;
                         longShootingCooldown = pawn.getRandom().nextBetween(20, 35);
                         shortShootingCooldown = pawn.getRandom().nextBetween(10, 15);
                     }
                 }
-            } else if (--this.cooldown <= 0 && this.targetSeeingTicker >= -60) {
+            } else if (this.targetSeeingTicker >= -60) {
                 pawn.setCurrentHand(ProjectileUtil.getHandPossiblyHolding(pawn, Items.BOW));
             }
         });
@@ -79,7 +75,6 @@ public class RangedAttackGoal extends AttackGoal {
     public void stop() {
         super.stop();
         this.targetSeeingTicker = 0;
-        this.cooldown = 0;
         if(pawn.isItemInHand(Items.BOW)) {
             pawn.clearActiveItem();
         }

--- a/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
+++ b/src/main/java/org/minefortress/entity/ai/goal/warrior/RangedAttackGoal.java
@@ -5,8 +5,9 @@ import net.minecraft.entity.projectile.ProjectileUtil;
 import net.minecraft.item.BowItem;
 import net.minecraft.item.Items;
 import net.minecraft.item.ShieldItem;
-import net.minecraft.util.math.Vec3d;
 import org.minefortress.entity.BasePawnEntity;
+
+import java.util.EnumSet;
 
 public class RangedAttackGoal extends AttackGoal {
     private int targetSeeingTicker = 0;
@@ -17,6 +18,7 @@ public class RangedAttackGoal extends AttackGoal {
 
     public RangedAttackGoal(BasePawnEntity pawn) {
         super(pawn);
+        this.setControls(EnumSet.of(Control.LOOK));
     }
 
     private void updateCooldowns() {
@@ -51,16 +53,7 @@ public class RangedAttackGoal extends AttackGoal {
                 --this.targetSeeingTicker;
             }
 
-            Vec3d targetPosition = target.getPos();
-            // If you have the high ground...
-            if(pawn.getPos().y > targetPosition.y)
-                // ...you better not to lose it.
-                // This will make archers be less inclined to back away,
-                // if the mob comes from downward direction.
-                // So archers will not jump off from towers and walls.
-                targetPosition = new Vec3d(targetPosition.x, targetPosition.y * 4, targetPosition.z);
-
-            double distance = pawn.getPos().squaredDistanceTo(targetPosition);
+            double distance = pawn.getPos().squaredDistanceTo(target.getPos());
 
             if (pawn.isUsingItem()) {
                 if (!visible && this.targetSeeingTicker < -60) {
@@ -87,14 +80,6 @@ public class RangedAttackGoal extends AttackGoal {
                 }
             } else if (--this.relaxCooldown <= 0 && this.targetSeeingTicker >= -60) {
                 pawn.setCurrentHand(ProjectileUtil.getHandPossiblyHolding(pawn, Items.BOW));
-            }
-
-            if (distance < 8.0 * 8.0) {
-                var away = pawn.getPos().subtract(target.getPos());
-                // What do you mean archers shouldn't escape from targets into the sky?
-                away = new Vec3d(away.x, 0.0, away.z);
-                away = away.normalize().multiply(pawn.getMovementSpeed());
-                pawn.addVelocity(away);
             }
         });
     }


### PR DESCRIPTION
Generic improvements:
- Update the target of a military pawn once in a while, since a better one may appear. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/438cbc83ad2db4b6012298db27c8b0fbd940cb0b))
- Disallow all pawns to move fast while using items, to bring parity with player behavior. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/91ff37eb0099f429ae2f2ea753bc6b255b514432))
- Don't try to reach the same target again and again once reached. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/bafba6363913462fa34c952d2c613092ffd90d7a))
- Prevent military pawns from eating food while still have target. This fixed strange behavior of archers when I readded ability to eat to them. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/53e7a41b51d41c1320f7131d26f87abffd56da0e))

Archer improvements:
- Remove reliance of archers on game difficulty. Not only it does not make sense (higher difficulty makes them more precise), but it is also unfair towards fortress players on easy difficulty, where the precision is atrocious. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/86d74d3d151dc07fcdb9af98fbb73d14e31b6dd0))
- Adjust direction that archers target by predicting movement of target. Since the range of archers is small, we can assume arrows move in a straight line, so we can compute how fast the arrow will reach the target, then use this time and target's velocity to compute estimated position. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/b9be8fcd6201c55c7aa252977ad147bee98f3c77))
- Make archers shoot at more random intervals and allow archers to use critical charges. Critical charges happen [40% of the time for far away shots](https://github.com/remmintan/minefortress/pull/60/commits/1f1040afdbdb3a94fffb1d0555c55426506085dd). ([how I did it](https://github.com/remmintan/minefortress/pull/60/commits/676530b86acd6197baef040a3de143ae0e138ff3) likely needs separate review)
- Changes to the cooldown in 1 second between shots. (cooldowns between shots removed [here](https://github.com/remmintan/minefortress/pull/60/commits/cd6d78612bb20987b162486a7b7938c8456e6f68), readded, but smaller in [this commit](https://github.com/remmintan/minefortress/pull/60/commits/96f55b323311207b251afe6c6f83cbfb1adaa038), but only for long attack intervals, which can do critical charges)
- The time that appears in between long shots can be used by archers to back away faster.
- Make them shoot faster if target is too close to knock it back, and when the player has shield in off-hand, and he put it down (maybe to eat, to heal, or something else), make them shoot faster to utilize this window to deal the most amount of damage. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/e13c4ac1dfd7840a1709e441d5c76e5c847bba1a))
- Make them back away if a target is too close. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/438cbc83ad2db4b6012298db27c8b0fbd940cb0b), refactored into its own goal [here](https://github.com/remmintan/minefortress/pull/60/commits/d9a09865a037f827fc1c43ed41f6f99e9c8abe2d))
    - Prefer not to do this on high ground (walls, towers, hills etc). ([commit](https://github.com/remmintan/minefortress/pull/60/commits/ef0c8f4fbfb09f121d20bd7c2b966fed418f914b))
    - Don't fall off the edges. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/75507e2e0475d6688ba8974b0a86e54e5da44448), additional adjustment [here](https://github.com/remmintan/minefortress/pull/60/commits/8b78be6120d7c288575d0b9adaaef4cc7248e078))
- Fix archers not healing for some odd reason. ([commit 1](https://github.com/remmintan/minefortress/pull/60/commits/99d24a9e8b08381ac9c6fcc6e51f296f74de3d1a), [commit 2](https://github.com/remmintan/minefortress/pull/60/commits/183c6f484aeea0e650191d575a1a8279cc243798), [commit 3](https://github.com/remmintan/minefortress/pull/60/commits/53e7a41b51d41c1320f7131d26f87abffd56da0e))
- This is unrelated to improvement, but it seems that wrong sound was using for arrow shot. Used sound was from skeleton instead from player. ([commit](https://github.com/remmintan/minefortress/pull/60/commits/93993e4875864f68dc9617e61dad4d62de02fb75))